### PR TITLE
allow lowWatermark to be set via options

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -34,7 +34,7 @@ function ESScrollStream(opts) {
 
     // buffer settings
     this.streamed = 0;
-    this.lowWaterMark = this.lowWaterMark || 1000;
+    this.lowWaterMark = opts.lowWaterMark || 1000;
 }
 inherits(ESScrollStream, Readable);
 


### PR DESCRIPTION
It looks to me that this was a small oversight/bug ... given that the docs/examples so `lowWatermark` being passed as an option ... unless I'm mistaken the line of code, as it stood, would always result in `this.lowWatermark` having the value `1000`:

``` js
    this.lowWaterMark = this.lowWaterMark || 1000;
```
